### PR TITLE
PR and active step in README bug fix

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -1,16 +1,12 @@
 name: Step 0, Start
 
-# This step triggers after the learner creates a new repository from the template
+# This step needs to be triggered manually after turning on the permission for actions to create and approve PRs in repository settings
 # This step sets STEP to 1
 # This step closes <details id=0> and opens <details id=1>
 
-# This will run every time we create push a commit to `main`
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
@@ -78,7 +74,7 @@ jobs:
       # Update README to close <details id=0> and open <details id=1>
       # and set STEP to '1'
       - name: Update to step 1
-        uses: skills/action-update-step@v1
+        uses: ./.github/workflows/update-step
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 0

--- a/.github/workflows/1-assign-yourself.yml
+++ b/.github/workflows/1-assign-yourself.yml
@@ -42,7 +42,7 @@ jobs:
       # Update README to close <details id=1> and open <details id=2>
       # and set STEP to '2'
       - name: Update to step 2
-        uses: skills/action-update-step@v1
+        uses: ./.github/workflows/update-step
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 1

--- a/.github/workflows/2-leave-a-review.yml
+++ b/.github/workflows/2-leave-a-review.yml
@@ -42,7 +42,7 @@ jobs:
       # Update README to close <details id=2> and open <details id=3>
       # and set STEP to '3'
       - name: Update to step 3
-        uses: skills/action-update-step@v1
+        uses: ./.github/workflows/update-step
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 2

--- a/.github/workflows/3-suggest-changes.yml
+++ b/.github/workflows/3-suggest-changes.yml
@@ -42,7 +42,7 @@ jobs:
       # Update README to close <details id=3> and open <details id=4>
       # and set STEP to '4'
       - name: Update to step 4
-        uses: skills/action-update-step@v1
+        uses: ./.github/workflows/update-step
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 3

--- a/.github/workflows/4-apply-changes.yml
+++ b/.github/workflows/4-apply-changes.yml
@@ -42,7 +42,7 @@ jobs:
       # Update README to close <details id=4> and open <details id=5>
       # and set STEP to '5'
       - name: Update to step 5
-        uses: skills/action-update-step@v1
+        uses: ./.github/workflows/update-step
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 4

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -1,16 +1,15 @@
 name: Step 5, Merge your pull request
 
-# This step triggers after a pull requst is merged to `main`
+# This step triggers after a pull requst is closed or merged
 # This step sets STEP to X
 # This step closes <details id=5> and opens <details id=X>
 
-# This will run every time we create push a commit to `main`
+# This will run every time we close or merge a pull request
 # Reference https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
 
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
@@ -41,7 +40,7 @@ jobs:
       # Update README to close <details id=5> and open <details id=X>
       # and set STEP to 'X'
       - name: Update to step X
-        uses: skills/action-update-step@v1
+        uses: ./.github/workflows/update-step
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 5

--- a/.github/workflows/update-step/action.yaml
+++ b/.github/workflows/update-step/action.yaml
@@ -1,0 +1,80 @@
+name: "Update step"
+description: "Update the course repository when the learner completes a step."
+inputs:
+  token:
+    description: "Set to [secrets.GITHUB_TOKEN]."
+    required: true
+  from_step:
+    description: "Requires the STEP file set to FROM_STEP."
+    required: true
+  to_step:
+    description: "The step number to go to next."
+    required: true
+  branch_name:
+    description: "If the learner is working in a branch, add the branch name."
+  base_branch_name:
+    description: "Optional name of the base branch (default: main)."
+    required: false
+    default: "main"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo "Check that all required env variables are set"
+        if [ -z "$TO_STEP" ]
+        then
+          echo "TO_STEP is unset or set to the empty string"
+          exit 1
+        fi
+        if [ -z "$FROM_STEP" ]
+        then
+          echo "FROM_STEP is unset or set to the empty string"
+          exit 1
+        fi
+        if [ -z "$GITHUB_TOKEN" ]
+        then
+          echo "GITHUB_TOKEN is unset or set to the empty string"
+          exit 1
+        fi
+
+        echo "Make sure we are on the base branch ($BASE_BRANCH_NAME)"
+        git checkout $BASE_BRANCH_NAME
+
+        echo "Check that we are on FROM_STEP"
+        if [ "$(cat .github/script/STEP)" != $FROM_STEP ]
+        then
+          echo "Current step is not $FROM_STEP"
+          exit 0
+        fi
+
+        echo "Remove 'open' from any <details> tags"
+        sed -i.tmp -r 's/<details id=([0-9X]+) open>/<details id=\1>/g' README.md
+
+        echo "Add 'open' to step TO_STEP"
+        sed -i.tmp -r "s/<details id=$TO_STEP>/<details id=$TO_STEP open>/g" README.md
+
+        echo "Update all HTML comments to hide everything"
+        sed -i.tmp -r 's/<!--step([0-9X]+)-->/<!--step\1/g' README.md
+        sed -i.tmp -r 's/<!--endstep([0-9X]+)-->/endstep\1-->/g' README.md
+
+        echo "Show the current TO_STEP"
+        sed -i.tmp -r "s/<\!--step$TO_STEP/<\!--step$TO_STEP-->/g" README.md
+        sed -i.tmp -r "s/endstep$TO_STEP-->/<\!--endstep$TO_STEP-->/g" README.md
+
+        echo "Update the STEP file to TO_STEP"
+        echo "$TO_STEP" > .github/script/STEP
+
+        echo "Commit the files, and push to base branch"
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add README.md
+        git add .github/script/STEP
+        git commit --message="Update to $TO_STEP in STEP and README.md"
+        git push
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        FROM_STEP: ${{ inputs.from_step }}
+        TO_STEP: ${{ inputs.to_step }}
+        BRANCH_NAME: ${{ inputs.branch_name }}
+        BASE_BRANCH_NAME: ${{ inputs.base_branch_name }}


### PR DESCRIPTION
### Why:

- GitHub action fails to run due to the absence of permission to create and approve pull requests by default in a newly created repository from this template.
- Steps don't expand and collapse automatically in the README due to a bug in the action-update-step workflow.
- Closes #22 

### What's being changed:

- The first workflow action (`0-start`) now needs to be triggered manually after turning on the create and approve pull requests permission for actions in repository settings.
- Fixed the `skills/action-update-step@v1` failing to expand and collapse steps automatically in the README. I removed the part where it was updating the STEP in the `update-game` branch and made the action check the current STEP in the base branch.
- Included a copy of the fixed `skills/action-update-step@v1` action in this repository itself to avoid interfering with any other actions using it as a dependency, and made all the actions use the repo version of this action instead of `skills/action-update-step@v1`
- The 5th workflow action (`5-merge-your-pull-request`) is now triggered for the PR closed event instead of the Push to main branch event.

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
