### PR TITLE
Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/1-assign-yourself.yml
+++ b/.github/workflows/1-assign-yourself.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
           ref: update-game

--- a/.github/workflows/2-leave-a-review.yml
+++ b/.github/workflows/2-leave-a-review.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
           ref: update-game

--- a/.github/workflows/3-suggest-changes.yml
+++ b/.github/workflows/3-suggest-changes.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
           ref: update-game

--- a/.github/workflows/4-apply-changes.yml
+++ b/.github/workflows/4-apply-changes.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
           ref: update-game

--- a/.github/workflows/5-merge-your-pull-request.yml
+++ b/.github/workflows/5-merge-your-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 


### PR DESCRIPTION
### Why:

Closes #22 (mainly resolved with skills/action-update-step@v1.2.1)
Node.js 12 actions are deprecated.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
Bump actions/checkout to v3

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
