### PR TITLE
chore: update commit button name and add navigation instructions

### DIFF
--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -33,7 +33,7 @@ The **Add a suggestion** feature is a button in the comment text editor. It inse
 
 ### :keyboard: Activity: Apply a suggested change
 
-1. In the pull request navigation, select the **Conversation** tab. 
+1. In the pull request navigation, select the **Conversation** tab.
 
 1. Scroll down and click the **Commit suggestion** button to open a commit message form.
 


### PR DESCRIPTION
### Summary

This PR updates the exercise instructions in [Step 4 of review-pull-request exercise](https://github.com/skills/review-pull-requests/blob/main/.github/steps/4-step.md#keyboard-activity-suggest-changes) to align with the current GitHub UI as of February 2026. The instructions before referenced buttons that might have been outdated, which could lead to user confusion during the "Suggest changes" exercise. 

### Changes

 - Changed references from **Add a single comment** to the current **Comment** button.
 - Added a step to navigate back to the **Conversation** tab to find the **Commit suggestion** button.

Closes: #116 

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
