### PR TITLE
fix: add missing step finished comment in step 1 workflow

### DIFF
--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -38,6 +38,15 @@ jobs:
           path: exercise-toolkit
           ref: v0.9.1
 
+      - name: Create comment - step finished
+        uses: GrantBirki/comment@v2.1.1
+        with:
+          repository: ${{ env.ISSUE_REPOSITORY }}
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
+          vars: |
+            next_step_number: 2
+
       - name: Create comment - add step content
         uses: GrantBirki/comment@v2.1.1
         with:


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Adding missing step finished comment in step 1 as reported by @bichobolita in https://github.com/skills/review-pull-requests/issues/125

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/review-pull-requests/issues/125

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
